### PR TITLE
Fix WebSocket client ID reset

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ wss.on('connection', function(ws) {
 
 wss.resend_ids = function(clients) {
   for (var i in this.clients) {
+    this.clients[i].id = parseInt(i, 10);
     this.clients[i].send(JSON.stringify({type:"id", id: i}));
   }
 }


### PR DESCRIPTION
## Summary
- update WebSocket server to resend numeric IDs and update clients when connections change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f452cbc848333a99b5ced8983ce1d