### PR TITLE
Fix keyword typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "video",
     "webrtc",
     "websockets",
-    "chatroulett"
+    "chatroulette"
   ],
   "author": "Michael Tsyganov",
   "license": "WTFPL",


### PR DESCRIPTION
## Summary
- fix a typo in `package.json`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f467f53a8833395df04c2a4e4ae29