### PR TITLE
Define default callback for ascii module

### DIFF
--- a/public/js/ascii.js
+++ b/public/js/ascii.js
@@ -63,6 +63,8 @@ var ascii = (function() {
     return Math.max(interval[0], Math.min(interval[1], value));
   }
 
+  function doNothing() {}
+
   return {
     fromCanvas: function(canvas, options) {
       options = options || {};


### PR DESCRIPTION
## Summary
- ensure ascii module always has a callback

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f468fbb908333b20279e8106d1c01