### PR TITLE
Add test for string-utils round trip

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fast and Simple html5 video conference over ASCII",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/string-utils.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/string-utils.test.js
+++ b/test/string-utils.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const code = fs.readFileSync(path.join(__dirname, '../public/js/string-utils.js'), 'utf8');
+const context = {};
+vm.createContext(context);
+vm.runInContext(code, context);
+
+const { str2ab, ab2str } = context;
+
+const original = 'Hello, world!';
+const buffer = str2ab(original);
+const roundTrip = ab2str(new Uint8Array(buffer));
+
+// ab2str appends null characters; trim them before comparison
+const cleaned = roundTrip.replace(/\0+$/, '');
+assert.strictEqual(cleaned, original);
+console.log('string-utils round-trip test passed');
+


### PR DESCRIPTION
## Summary
- add initial node test verifying `str2ab` and `ab2str`
- run test via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f46a1894c8333984b233ee98b1f7b